### PR TITLE
Enables lookups for custom file extensions

### DIFF
--- a/bin/hiera_explain
+++ b/bin/hiera_explain
@@ -139,8 +139,15 @@ Hiera::Config[:backends].each do |backend|
   datadir = Hiera::Backend.datadir(backend, scope)
   next unless datadir
 
+  # backend like eyaml allow for custom file-extensions
+  unless Hiera::Config[backend.to_sym][:extension].nil?
+    extension = Hiera::Config[backend.to_sym][:extension]
+  else
+    extension = backend
+  end
+
   Hiera::Backend.datasources(scope) do |source|
-    path = File.join(datadir, "#{source}.#{backend}")
+    path = File.join(datadir, "#{source}.#{extension}")
 
     unless File.exists?(path)
       puts "  [ ] #{path}".red
@@ -167,7 +174,7 @@ Hiera::Config[:backends].each do |backend|
           hash_sources[key]  << path
         else
           hash_errors[key] ||= Array.new
-          hash_errors[key]  << "#{source}.#{backend}"
+          hash_errors[key]  << "#{source}.#{extension}"
         end
       end
 


### PR DESCRIPTION
Hiera backends like eyaml allow for custom file-extensions. This allows for example to use the `.yaml` extension for eyaml, instead for the default `.eyaml` extension. 
This commit enables hiera_explain to lookup and use the custom file-extension, if configured for a backend.

On eyaml extensions: https://github.com/voxpupuli/hiera-eyaml/blob/master/README.md

Example output of eyaml backend using the `.yaml` extension:

```
# /opt/puppetlabs/puppet/bin/ruby -I$PWD/lib bin/hiera_explain -f foo
Backend data directories:
  * eyaml: /etc/puppetlabs/hieradata

Expanded hierarchy:
  * common

File lookup order:
  [X] /etc/puppetlabs/hieradata/common.yaml

Priority lookup results:
   * hiera('foo') => bar

Array lookup results:
   * hiera_array('foo') => ["bar"]

Hash lookup results:
   * hiera_hash('foo') => Not a hash datatype in ["common.yaml"]

```


Example output of eyaml backend using the default (or no configured) extension:

```
# /opt/puppetlabs/puppet/bin/ruby -I$PWD/lib bin/hiera_explain -f foo
Backend data directories:
  * eyaml: /etc/puppetlabs/hieradata

Expanded hierarchy:
  * common

File lookup order:
  [ ] /etc/puppetlabs/hieradata/common.eyaml

Priority lookup results:

Array lookup results:

Hash lookup results:

```
